### PR TITLE
Adds new graceful failure feature to forecasted cells table so it ser…

### DIFF
--- a/database/init.sql
+++ b/database/init.sql
@@ -67,14 +67,15 @@ CREATE TABLE IF NOT EXISTS cell_interpolated (
     FOREIGN KEY (cell_id) REFERENCES cell_neighbors (cell_id)
 );
 
+-- One row per cell: holds the latest successful forecast. Cells that fail a run
+-- keep their previous row (upserted via ON CONFLICT(cell_id) DO UPDATE).
 CREATE TABLE IF NOT EXISTS cell_forecasts (
-    cell_id INTEGER NOT NULL,
+    cell_id INTEGER PRIMARY KEY,
     timestamp TEXT NOT NULL,
     precipitation_t1 REAL,
     precipitation_t3 REAL,
     precipitation_t6 REAL,
     precipitation_t12 REAL,
-    CONSTRAINT unique_cell_forecast UNIQUE (cell_id, timestamp),
     FOREIGN KEY (cell_id) REFERENCES cell_neighbors (cell_id)
 );
 

--- a/src/weather_engine/api.py
+++ b/src/weather_engine/api.py
@@ -45,7 +45,7 @@ def get_map(horizon: str = "precipitation_t1"):
     else:
         rows = get_forecast_rows()
         fol_map = build_forecast_map(rows, horizon=horizon)
-        ts = rows[0]["timestamp"]
+        ts = max(r["timestamp"] for r in rows)
     return HTMLResponse(content=render_map_section(fol_map._repr_html_(), horizon, ts, mode="live"))
 
 

--- a/src/weather_engine/cache.py
+++ b/src/weather_engine/cache.py
@@ -10,7 +10,7 @@ _timestamps = None
 
 
 def get_forecast_timestamp() -> str | None:
-    query = "SELECT timestamp FROM cell_forecasts LIMIT 1"
+    query = "SELECT MAX(timestamp) FROM cell_forecasts"
     with SessionLocal() as db:
         row = db.execute(text(query)).fetchone()
         return row[0] if row else None

--- a/src/weather_engine/inference_pipeline.py
+++ b/src/weather_engine/inference_pipeline.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import xgboost as xgb
 from datetime import datetime, timedelta, timezone
-from sqlalchemy import text, types
+from sqlalchemy import MetaData, Table, text, types
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from weather_engine.database import engine
@@ -322,12 +322,20 @@ def forecast_and_store(cell_neighbors: pd.DataFrame, station_frames: dict, model
         return
 
     forecasts = pd.concat(records)
+    # Match the stored TEXT format so MAX(timestamp) string comparison stays valid
+    forecasts['timestamp'] = forecasts['timestamp'].dt.strftime('%Y-%m-%d %H:%M:%S.%f')
 
-    with engine.begin() as conn:  # type: ignore[reportUnreachable]
-        conn.execute(text("DELETE FROM cell_forecasts"))
+    # Upsert per cell: cells that failed this run keep their last known good forecast
+    table = Table('cell_forecasts', MetaData(), autoload_with=engine)
+    stmt = sqlite_insert(table)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=['cell_id'],
+        set_={c.name: stmt.excluded[c.name] for c in table.columns if c.name != 'cell_id'},
+    )
+    with engine.begin() as conn:
+        conn.execute(stmt, forecasts.to_dict('records'))
 
-    forecasts.to_sql('cell_forecasts', engine, if_exists='append', index=False)
-    print(f"Replaced cell_forecasts with {len(forecasts)} rows.")
+    print(f"Upserted {len(forecasts)}/{len(cell_neighbors)} cells into cell_forecasts.")
 
 
 def main() -> None:


### PR DESCRIPTION
…ves last valid forecast for all cells and updates the ones that are getting updated. This comes along with a schema change making cell_id the primary key since each cell only has one row of forecasts that has all horizons. Also small changes to api and cache so they fetch the latest timestamp rather than a arbitrary row